### PR TITLE
Erc20 Incentives Controller for FEI listing in Aave V2 Ethereum Market

### DIFF
--- a/contracts/incentives/ERC20TokenIncentivesController.sol
+++ b/contracts/incentives/ERC20TokenIncentivesController.sol
@@ -26,8 +26,7 @@ contract ERC20TokenIncentivesController is
 
   uint256 public constant REVISION = 1;
 
-  /// @inheritdoc IAaveIncentivesController
-  address public immutable override REWARD_TOKEN;
+  address public immutable TOKEN;
 
   mapping(address => uint256) internal _usersUnclaimedRewards;
 
@@ -43,7 +42,7 @@ contract ERC20TokenIncentivesController is
   constructor(address rewardToken, address emissionManager)
     DistributionManager(emissionManager)
   {
-    REWARD_TOKEN = rewardToken;
+    TOKEN = rewardToken;
   }
 
   /// @inheritdoc IAaveIncentivesController
@@ -147,6 +146,11 @@ contract ERC20TokenIncentivesController is
     return _usersUnclaimedRewards[_user];
   }
 
+  /// @inheritdoc IAaveIncentivesController
+  function REWARD_TOKEN() external view override returns (address) {
+    return address(TOKEN);
+  }
+
   /**
    * @dev returns the revision of the implementation contract
    */
@@ -194,7 +198,7 @@ contract ERC20TokenIncentivesController is
     uint256 amountToClaim = amount > unclaimedRewards ? unclaimedRewards : amount;
     _usersUnclaimedRewards[user] = unclaimedRewards - amountToClaim; // Safe due to the previous line
 
-    IERC20(REWARD_TOKEN).transfer(to, amountToClaim);
+    IERC20(TOKEN).transfer(to, amountToClaim);
     emit RewardsClaimed(user, to, claimer, amountToClaim);
 
     return amountToClaim;

--- a/contracts/incentives/ERC20TokenIncentivesController.sol
+++ b/contracts/incentives/ERC20TokenIncentivesController.sol
@@ -45,6 +45,14 @@ contract ERC20TokenIncentivesController is
     TOKEN = rewardToken;
   }
 
+  /**
+   * @dev Initialize IERC20TokenIncentivesController
+   * @param addressesProvider the address of the corresponding addresses provider
+   **/
+  function initialize(address addressesProvider) external initializer {
+    // no-op
+  }
+
   /// @inheritdoc IAaveIncentivesController
   function configureAssets(address[] calldata assets, uint256[] calldata emissionsPerSecond)
     external
@@ -148,7 +156,7 @@ contract ERC20TokenIncentivesController is
 
   /// @inheritdoc IAaveIncentivesController
   function REWARD_TOKEN() external view override returns (address) {
-    return address(TOKEN);
+    return TOKEN;
   }
 
   /**

--- a/contracts/incentives/ERC20TokenIncentivesController.sol
+++ b/contracts/incentives/ERC20TokenIncentivesController.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.7.5;
+pragma experimental ABIEncoderV2;
+
+import {SafeERC20} from '@aave/aave-stake/contracts/lib/SafeERC20.sol';
+import {SafeMath} from '../lib/SafeMath.sol';
+import {DistributionTypes} from '../lib/DistributionTypes.sol';
+import {VersionedInitializable} from '@aave/aave-stake/contracts/utils/VersionedInitializable.sol';
+import {DistributionManager} from './DistributionManager.sol';
+import {IERC20} from '@aave/aave-stake/contracts/interfaces/IERC20.sol';
+import {IScaledBalanceToken} from '../interfaces/IScaledBalanceToken.sol';
+import {IAaveIncentivesController} from '../interfaces/IAaveIncentivesController.sol';
+
+/**
+ * @title ERC20TokenIncentivesController
+ * @notice Distributor contract for rewards to the Aave protocol, using a regular ERC20 token as rewards asset.
+ * @author Aave, Joey Santoro
+ **/
+contract ERC20TokenIncentivesController is
+  IAaveIncentivesController,
+  VersionedInitializable,
+  DistributionManager
+{
+  using SafeMath for uint256;
+  using SafeERC20 for IERC20;
+
+  uint256 public constant REVISION = 1;
+
+  /// @inheritdoc IAaveIncentivesController
+  address public immutable override REWARD_TOKEN;
+
+  mapping(address => uint256) internal _usersUnclaimedRewards;
+
+  // this mapping allows whitelisted addresses to claim on behalf of others
+  // useful for contracts that hold tokens to be rewarded but don't have any native logic to claim Liquidity Mining rewards
+  mapping(address => address) internal _authorizedClaimers;
+
+  modifier onlyAuthorizedClaimers(address claimer, address user) {
+    require(_authorizedClaimers[user] == claimer, 'CLAIMER_UNAUTHORIZED');
+    _;
+  }
+
+  constructor(address rewardToken, address emissionManager)
+    DistributionManager(emissionManager)
+  {
+    REWARD_TOKEN = rewardToken;
+  }
+
+  /// @inheritdoc IAaveIncentivesController
+  function configureAssets(address[] calldata assets, uint256[] calldata emissionsPerSecond)
+    external
+    override
+    onlyEmissionManager
+  {
+    require(assets.length == emissionsPerSecond.length, 'INVALID_CONFIGURATION');
+
+    DistributionTypes.AssetConfigInput[] memory assetsConfig =
+      new DistributionTypes.AssetConfigInput[](assets.length);
+
+    for (uint256 i = 0; i < assets.length; i++) {
+      assetsConfig[i].underlyingAsset = assets[i];
+      assetsConfig[i].emissionPerSecond = uint104(emissionsPerSecond[i]);
+
+      require(assetsConfig[i].emissionPerSecond == emissionsPerSecond[i], 'INVALID_CONFIGURATION');
+
+      assetsConfig[i].totalStaked = IScaledBalanceToken(assets[i]).scaledTotalSupply();
+    }
+    _configureAssets(assetsConfig);
+  }
+
+  /// @inheritdoc IAaveIncentivesController
+  function handleAction(
+    address user,
+    uint256 totalSupply,
+    uint256 userBalance
+  ) external override {
+    uint256 accruedRewards = _updateUserAssetInternal(user, msg.sender, userBalance, totalSupply);
+    if (accruedRewards != 0) {
+      _usersUnclaimedRewards[user] = _usersUnclaimedRewards[user].add(accruedRewards);
+      emit RewardsAccrued(user, accruedRewards);
+    }
+  }
+
+  /// @inheritdoc IAaveIncentivesController
+  function getRewardsBalance(address[] calldata assets, address user)
+    external
+    view
+    override
+    returns (uint256)
+  {
+    uint256 unclaimedRewards = _usersUnclaimedRewards[user];
+
+    DistributionTypes.UserStakeInput[] memory userState =
+      new DistributionTypes.UserStakeInput[](assets.length);
+    for (uint256 i = 0; i < assets.length; i++) {
+      userState[i].underlyingAsset = assets[i];
+      (userState[i].stakedByUser, userState[i].totalStaked) = IScaledBalanceToken(assets[i])
+        .getScaledUserBalanceAndSupply(user);
+    }
+    unclaimedRewards = unclaimedRewards.add(_getUnclaimedRewards(user, userState));
+    return unclaimedRewards;
+  }
+
+  /// @inheritdoc IAaveIncentivesController
+  function claimRewards(
+    address[] calldata assets,
+    uint256 amount,
+    address to
+  ) external override returns (uint256) {
+    require(to != address(0), 'INVALID_TO_ADDRESS');
+    return _claimRewards(assets, amount, msg.sender, msg.sender, to);
+  }
+
+  /// @inheritdoc IAaveIncentivesController
+  function claimRewardsOnBehalf(
+    address[] calldata assets,
+    uint256 amount,
+    address user,
+    address to
+  ) external override onlyAuthorizedClaimers(msg.sender, user) returns (uint256) {
+    require(user != address(0), 'INVALID_USER_ADDRESS');
+    require(to != address(0), 'INVALID_TO_ADDRESS');
+    return _claimRewards(assets, amount, msg.sender, user, to);
+  }
+
+  /**
+   * @dev Claims reward for an user on behalf, on all the assets of the lending pool, accumulating the pending rewards.
+   * @param amount Amount of rewards to claim
+   * @param user Address to check and claim rewards
+   * @param to Address that will be receiving the rewards
+   * @return Rewards claimed
+   **/
+
+  /// @inheritdoc IAaveIncentivesController
+  function setClaimer(address user, address caller) external override onlyEmissionManager {
+    _authorizedClaimers[user] = caller;
+    emit ClaimerSet(user, caller);
+  }
+
+  /// @inheritdoc IAaveIncentivesController
+  function getClaimer(address user) external view override returns (address) {
+    return _authorizedClaimers[user];
+  }
+
+  /// @inheritdoc IAaveIncentivesController
+  function getUserUnclaimedRewards(address _user) external view override returns (uint256) {
+    return _usersUnclaimedRewards[_user];
+  }
+
+  /**
+   * @dev returns the revision of the implementation contract
+   */
+  function getRevision() internal pure override returns (uint256) {
+    return REVISION;
+  }
+
+  /**
+   * @dev Claims reward for an user on behalf, on all the assets of the lending pool, accumulating the pending rewards.
+   * @param amount Amount of rewards to claim
+   * @param user Address to check and claim rewards
+   * @param to Address that will be receiving the rewards
+   * @return Rewards claimed
+   **/
+  function _claimRewards(
+    address[] calldata assets,
+    uint256 amount,
+    address claimer,
+    address user,
+    address to
+  ) internal returns (uint256) {
+    if (amount == 0) {
+      return 0;
+    }
+    uint256 unclaimedRewards = _usersUnclaimedRewards[user];
+
+    DistributionTypes.UserStakeInput[] memory userState =
+      new DistributionTypes.UserStakeInput[](assets.length);
+    for (uint256 i = 0; i < assets.length; i++) {
+      userState[i].underlyingAsset = assets[i];
+      (userState[i].stakedByUser, userState[i].totalStaked) = IScaledBalanceToken(assets[i])
+        .getScaledUserBalanceAndSupply(user);
+    }
+
+    uint256 accruedRewards = _claimRewards(user, userState);
+    if (accruedRewards != 0) {
+      unclaimedRewards = unclaimedRewards.add(accruedRewards);
+      emit RewardsAccrued(user, accruedRewards);
+    }
+
+    if (unclaimedRewards == 0) {
+      return 0;
+    }
+
+    uint256 amountToClaim = amount > unclaimedRewards ? unclaimedRewards : amount;
+    _usersUnclaimedRewards[user] = unclaimedRewards - amountToClaim; // Safe due to the previous line
+
+    IERC20(REWARD_TOKEN).transfer(to, amountToClaim);
+    emit RewardsClaimed(user, to, claimer, amountToClaim);
+
+    return amountToClaim;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "coverage": "hardhat coverage",
     "test": "npm run test-incentives",
     "test-incentives": "TS_NODE_TRANSPILE_ONLY=1 hardhat test ./test/__setup.spec.ts ./test/AaveIncentivesController/*.spec.ts",
+    "test-incentives:erc20": "TS_NODE_TRANSPILE_ONLY=1 ERC20_INCENTIVES=1 hardhat test ./test/__setup.spec.ts ./test/AaveIncentivesController/*[!initialize].spec.ts",
     "test-proposal": "TS_NODE_TRANSPILE_ONLY=1 MAINNET_FORK=true hardhat test ./test-fork/incentivesProposal.spec.ts",
     "test-proposal:tenderly": "TS_NODE_TRANSPILE_ONLY=1 TENDERLY=true npm run hardhat:tenderly -- test ./test-fork/incentivesProposal.spec.ts",
     "test-proposal-skip": "TS_NODE_TRANSPILE_ONLY=1 MAINNET_FORK=true hardhat test ./test-fork/incentives-skip.spec.ts",

--- a/test/__setup.spec.ts
+++ b/test/__setup.spec.ts
@@ -6,7 +6,7 @@ import { deployMintableErc20, deployATokenMock } from '../helpers/contracts-acce
 import { waitForTx } from '../helpers/misc-utils';
 import { MintableErc20 } from '../types/MintableErc20';
 import { testDeployIncentivesController } from './helpers/deploy';
-import { StakedAaveV3__factory, StakedTokenIncentivesController__factory } from '../types';
+import { StakedAaveV3__factory, StakedTokenIncentivesController__factory, ERC20TokenIncentivesController__factory } from '../types';
 import { parseEther } from '@ethersproject/units';
 
 const topUpWalletsWithAave = async (
@@ -45,7 +45,8 @@ const buildTestEnv = async (
   await deployATokenMock(incentivesProxy.address, 'aDai');
   await deployATokenMock(incentivesProxy.address, 'aWeth');
 
-  const incentivesController = StakedTokenIncentivesController__factory.connect(
+  const factory = process.env.ERC20_INCENTIVES ? ERC20TokenIncentivesController__factory : StakedTokenIncentivesController__factory;
+  const incentivesController = factory.connect(
     incentivesProxy.address,
     deployer
   );

--- a/test/helpers/make-suite.ts
+++ b/test/helpers/make-suite.ts
@@ -9,7 +9,7 @@ import bignumberChai from 'chai-bignumber';
 import { getATokenMock } from '../../helpers/contracts-accessors';
 import { MintableErc20 } from '../../types/MintableErc20';
 import { ATokenMock } from '../../types/ATokenMock';
-import { StakedAaveV3, StakedTokenIncentivesController } from '../../types';
+import { StakedAaveV3, IAaveIncentivesController } from '../../types';
 
 chai.use(bignumberChai());
 
@@ -27,7 +27,7 @@ export interface TestEnv {
   deployer: SignerWithAddress;
   users: SignerWithAddress[];
   aaveToken: MintableErc20;
-  aaveIncentivesController: StakedTokenIncentivesController;
+  aaveIncentivesController: IAaveIncentivesController;
   stakedAave: StakedAaveV3;
   aDaiMock: ATokenMock;
   aWethMock: ATokenMock;
@@ -45,7 +45,7 @@ const testEnv: TestEnv = {
   users: [] as SignerWithAddress[],
   aaveToken: {} as MintableErc20,
   stakedAave: {} as StakedAaveV3,
-  aaveIncentivesController: {} as StakedTokenIncentivesController,
+  aaveIncentivesController: {} as IAaveIncentivesController,
   aDaiMock: {} as ATokenMock,
   aWethMock: {} as ATokenMock,
 } as TestEnv;
@@ -53,7 +53,7 @@ const testEnv: TestEnv = {
 export async function initializeMakeSuite(
   aaveToken: MintableErc20,
   stakedAave: StakedAaveV3,
-  aaveIncentivesController: StakedTokenIncentivesController
+  aaveIncentivesController: IAaveIncentivesController
 ) {
   const [_deployer, _proxyAdmin, ...restSigners] = await getEthersSigners();
   const deployer: SignerWithAddress = {


### PR DESCRIPTION
Adds an incentives controller which supports non-staked ERC-20 tokens like TRIBE.

To run tests, `npm run test-incentives:erc20`

Diff of ERC20TokenIncentivesController vs StakedTokenIncentivesController `https://www.diffchecker.com/v4GXHJXS`

This is the command I used to deploy the [TRIBE Incentives Controller](https://etherscan.io/address/0xFF865335401F12B88fa3FF5A3a51685A7f224191) : `STAKE_TOKEN='0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B' EMISSIONS_MANAGER='0x639572471f2f318464dc01066a56867130e45E25' ERC20_INCENTIVES=1 npm run deploy:incentives-controller-impl:main`